### PR TITLE
Use a browser only if it is running

### DIFF
--- a/tabs.js
+++ b/tabs.js
@@ -16,6 +16,10 @@ const hasTabs = window => {
 	}
 };
 
+const isRunning = app => {
+	return app.running();
+};
+
 const getAppWindows = app => app
 	.windows()
 	.filter(window => window.name() && hasTabs(window))
@@ -71,6 +75,7 @@ function run(argv) {
 	const query = argv[0].toLowerCase().normalize();
 	const tabs = ['Safari', 'Google Chrome']
 		.filter(hasApp)
+		.filter(isRunning)
 		.map(name => Application(name))
 		.map(getAppWindows)
 		.reduce((a, b) => a.concat(b), [])


### PR DESCRIPTION
Thank you for building this application!

The previous code opened a browser and halted if it was not running.
This fix filters non-running browsers before examining tabs.

Partially fixes PR #2

ps. On the check function,  I opened a new bracket just to follow the existing coding style, but I can fix it to do the check in a one-liner if you'd like.